### PR TITLE
feat: Add animated bio cards to detail pages

### DIFF
--- a/app/src/main/java/com/google/developer/udacityalumni/fragment/ArticleDetailFragment.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/fragment/ArticleDetailFragment.java
@@ -43,6 +43,9 @@ public class ArticleDetailFragment extends Fragment
     private long mArticleId, mNextArticleId;
     private boolean mIsFollowing;
 
+    private SlidingViewManager mSlidingViewManager;
+    private AvatarCardAdapter mSlidingViewAdapter;
+
     @BindView(R.id.detail_article_title_tv)
     TextView mTitleTV;
     @BindView(R.id.detail_article_image)
@@ -110,7 +113,21 @@ public class ArticleDetailFragment extends Fragment
                 }
             }
         }
+
+        mSlidingViewManager = new SlidingViewManager(this);
+        mSlidingViewAdapter = new AvatarCardAdapter(slidingCardClickListener);
+        mSlidingViewManager.setAdapter(mSlidingViewAdapter);
+        if (savedInstanceState != null) {
+            mSlidingViewManager.onRestoreInstanceState(savedInstanceState);
+        }
+
         return rootView;
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        mSlidingViewManager.onSaveInstanceState(outState);
     }
 
     @Override
@@ -165,7 +182,8 @@ public class ArticleDetailFragment extends Fragment
                     Picasso.with(getContext()).load(image).placeholder(R.drawable.placeholder)
                             .error(R.drawable.udacity_logo_banner).into(mImageView);
                 }
-                mArticleTV.setText(data.getString(ArticleFragment.IND_CONTENT));
+                String content = data.getString(ArticleFragment.IND_CONTENT);
+                mArticleTV.setText(content);
                 String profPic = data.getString(ArticleFragment.IND_USER_AVATAR);
                 if (profPic == null || TextUtils.isEmpty(image) || profPic.equals("null")) {
                     mProfPicCV.setImageResource(R.drawable.ic_person);
@@ -177,6 +195,10 @@ public class ArticleDetailFragment extends Fragment
                         data.getLong(ArticleFragment.IND_CREATED_AT)));
                 mIsFollowing = data.getInt(ArticleFragment.IND_FOLLOWING_AUTHOR) == 1;
                 setFollowingIcon();
+
+                mSlidingViewAdapter.setName(author);
+                mSlidingViewAdapter.setImageUri(Uri.parse(profPic));
+                mSlidingViewAdapter.setContent(content);
             }
 
         }
@@ -215,6 +237,7 @@ public class ArticleDetailFragment extends Fragment
                 break;
             case R.id.detail_article_prof_pic:
                 //TODO: have user bio pane slide from bottom;
+                mSlidingViewManager.animate();
                 break;
             case R.id.detail_article_preview_ll:
                 ((DetailArticleCallbacks) getActivity()).onNextArticleClicked();
@@ -225,4 +248,18 @@ public class ArticleDetailFragment extends Fragment
     private void setFollowingIcon() {
         mFollowIV.setImageResource(mIsFollowing ? R.drawable.ic_following : R.drawable.ic_add_follow);
     }
+
+    private final AvatarCardAdapter.OnClickListener slidingCardClickListener =
+            new AvatarCardAdapter.OnClickListener() {
+        @Override
+        public void onSeeMoreClick() {
+            Toast.makeText(getContext(), "See More Clicked", Toast.LENGTH_SHORT).show();
+        }
+
+        @Override
+        public void onDismissClick() {
+            mSlidingViewManager.animate();
+        }
+    };
+
 }

--- a/app/src/main/java/com/google/developer/udacityalumni/view/ViewUtils.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/view/ViewUtils.java
@@ -3,7 +3,7 @@ package com.google.developer.udacityalumni.view;
 import android.content.res.Resources;
 
 /**
- * Created by tom on 18/01/17.
+ * Created by Tom Calver on 18/01/17.
  */
 
 public final class ViewUtils {
@@ -12,6 +12,10 @@ public final class ViewUtils {
 
     public static int pxToDp(int px) {
         return (int) (px / Resources.getSystem().getDisplayMetrics().density);
+    }
+
+    public static int dpToPx(int dp) {
+        return (int) (dp * Resources.getSystem().getDisplayMetrics().density);
     }
 
 }

--- a/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/AvatarCardAdapter.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/AvatarCardAdapter.java
@@ -106,6 +106,7 @@ public final class AvatarCardAdapter implements SlidingView, View.OnClickListene
 
     @Override
     public void setParcelableData(Parcelable data) {
+        if(data == null) return;
         final Options options = (Options) data;
         setContent(options.content);
         setName(options.name);

--- a/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/AvatarCardAdapter.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/AvatarCardAdapter.java
@@ -101,7 +101,7 @@ public final class AvatarCardAdapter implements SlidingView, View.OnClickListene
                 .setName(name)
                 .setImageUri(imageUri)
                 .setContent(content)
-                .setSeeMoreClickListener(listener);
+                .setClickListener(listener);
     }
 
     @Override
@@ -161,7 +161,7 @@ public final class AvatarCardAdapter implements SlidingView, View.OnClickListene
             return this;
         }
 
-        public Options setSeeMoreClickListener(@NonNull OnClickListener listener) {
+        public Options setClickListener(@NonNull OnClickListener listener) {
             this.listener = listener;
             return this;
         }

--- a/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/SlidingViewManager.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/SlidingViewManager.java
@@ -165,7 +165,9 @@ public final class SlidingViewManager implements View.OnTouchListener, ViewTreeO
 
     public void onSaveInstanceState(@NonNull Bundle bundle) {
         bundle.putBoolean(STATE_KEY, isExpanded);
-        bundle.putParcelable(OPTIONS_KEY, mAdapter.getParcelableData());
+        if (mAdapter != null) {
+            bundle.putParcelable(OPTIONS_KEY, mAdapter.getParcelableData());
+        }
     }
 
     public void onRestoreInstanceState(@NonNull Bundle bundle) {

--- a/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/SlidingViewManager.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/SlidingViewManager.java
@@ -37,7 +37,7 @@ public final class SlidingViewManager implements View.OnTouchListener, ViewTreeO
     private static final String STATE_KEY = TAG + ".STATE_KEY";
     private static final String OPTIONS_KEY = TAG + ".OPTIONS_KEY";
     private static final int ANIMATION_DURATION = 500;
-    private static final int SLIDING_CARD_ELEVATION = ViewUtils.pxToDp(24);
+    private static final int SLIDING_CARD_ELEVATION = ViewUtils.dpToPx(16);
 
     private boolean isExpanded = false, isAnimating = false;
 

--- a/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/SlidingViewManager.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/SlidingViewManager.java
@@ -76,6 +76,10 @@ public final class SlidingViewManager implements View.OnTouchListener, ViewTreeO
 
     public void setAdapter(SlidingView adapter) {
         mAdapter = adapter;
+        final View contentView = mSlidingView.getChildAt(0);
+        if (contentView != null) {
+            mSlidingView.removeView(contentView);
+        }
         mSlidingView.addView(mAdapter.onCreateView(mSlidingView));
     }
 

--- a/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/SlidingViewManager.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/SlidingViewManager.java
@@ -225,10 +225,10 @@ public final class SlidingViewManager implements View.OnTouchListener, ViewTreeO
                 mScrim.setVisibility(View.VISIBLE);
                 mScrim.setBackgroundColor(endColor);
             } else {
-                ViewCompat.setTranslationY(mSlidingView, mSlidingView.getHeight());
+                ViewCompat.setTranslationY(mSlidingView, height);
                 mSlidingView.setVisibility(View.GONE);
                 mScrim.setVisibility(View.GONE);
-                mScrim.setBackgroundColor(Color.TRANSPARENT);
+                mScrim.setBackgroundColor(startColor);
             }
             mSlidingView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
         }

--- a/app/src/main/res/layout/avatar_sliding_card.xml
+++ b/app/src/main/res/layout/avatar_sliding_card.xml
@@ -12,7 +12,7 @@
         android:layout_height="@dimen/sliding_view_avatar_size"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
-        android:src="@drawable/ic_launcher"/>
+        tools:src="@drawable/ic_launcher"/>
 
     <TextView
         android:id="@+id/sliding_card_name"
@@ -52,6 +52,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:maxLines="4"
+        android:ellipsize="end"
         android:layout_below="@+id/sliding_card_divider"
         tools:text="Here would be some text about Oscar.\n\nDid you know he makes apps? He isn't bad either."/>
 


### PR DESCRIPTION
### Summary

Adds the cards that will eventually contain user bios, that slide in from the bottom of the screen, to the detail article pages.

Also contains some small fixes related to these cards.

See: Pull Request #32 and Issue #5