### PR TITLE
feat: Add Animated Card for User Bios to Main User List

### DIFF
--- a/app/src/main/java/com/google/developer/udacityalumni/adapter/PostFirebaseAdapter.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/adapter/PostFirebaseAdapter.java
@@ -1,0 +1,46 @@
+package com.google.developer.udacityalumni.adapter;
+
+import android.content.Context;
+import android.view.View;
+
+import com.firebase.ui.database.FirebaseRecyclerAdapter;
+import com.google.developer.udacityalumni.R;
+import com.google.developer.udacityalumni.model.Post;
+import com.google.developer.udacityalumni.viewholder.PostViewHolder;
+import com.google.firebase.database.Query;
+import com.google.firebase.storage.FirebaseStorage;
+
+/**
+ *
+ * Created by Tom Calver on 28/01/17.
+ */
+
+public final class PostFirebaseAdapter extends FirebaseRecyclerAdapter<Post, PostViewHolder> {
+
+    private final OnClickListener mListener;
+
+    public PostFirebaseAdapter(Query query, OnClickListener listener) {
+        super(Post.class, R.layout.item_post, PostViewHolder.class, query);
+        mListener = listener;
+    }
+
+    @Override
+    protected void populateViewHolder(final PostViewHolder viewHolder, final Post post, int position) {
+
+        final Context ctx = viewHolder.itemView.getContext();
+        final FirebaseStorage storage = FirebaseStorage.getInstance();
+
+        viewHolder.bindToPost(post, ctx, storage);
+        viewHolder.setAvatarOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mListener.onAvatarClicked(post);
+            }
+        });
+    }
+
+    public interface OnClickListener {
+        void onAvatarClicked(Post post);
+    }
+
+}

--- a/app/src/main/java/com/google/developer/udacityalumni/fragment/PostFragment.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/fragment/PostFragment.java
@@ -85,7 +85,7 @@ public class PostFragment extends Fragment implements PostFirebaseAdapter.OnClic
     public void onAvatarClicked(Post post) {
         //todo Replace 'Content' with User Bio
         mSlidingViewAdapter.setContent(post.text);
-        mSlidingViewAdapter.setImageUri(Uri.parse(post.userProfPic));
+        mSlidingViewAdapter.setImageUri(post.userProfPic);
         mSlidingViewAdapter.setName(post.userName);
         mSlidingViewManager.animate();
     }

--- a/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/AvatarCardAdapter.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/AvatarCardAdapter.java
@@ -4,6 +4,8 @@ import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,6 +13,7 @@ import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.developer.udacityalumni.R;
 import com.squareup.picasso.Picasso;
@@ -30,8 +33,6 @@ public final class AvatarCardAdapter implements SlidingView, View.OnClickListene
 
     private ImageView mAvatarImageView;
     private TextView mNameTextView, mContentTextView;
-    private Button mSeeMoreButton;
-    private ImageButton mDismissButton;
 
     public AvatarCardAdapter(OnClickListener listener) {
         this.listener = listener;
@@ -46,6 +47,13 @@ public final class AvatarCardAdapter implements SlidingView, View.OnClickListene
 
     public void setListener(OnClickListener listener) {
         this.listener = listener;
+    }
+
+    public void setImageUri(String imageUri) {
+        if (imageUri == null) {
+            setImageUri(Uri.EMPTY);
+        }
+        setImageUri(Uri.parse(imageUri));
     }
 
     public void setImageUri(Uri imageUri) {
@@ -78,19 +86,16 @@ public final class AvatarCardAdapter implements SlidingView, View.OnClickListene
         mAvatarImageView = (ImageView) view.findViewById(R.id.sliding_card_avatar);
         mNameTextView = (TextView) view.findViewById(R.id.sliding_card_name);
         mContentTextView = (TextView) view.findViewById(R.id.sliding_card_content);
-        mSeeMoreButton = (Button) view.findViewById(R.id.sliding_card_see_more);
-        mDismissButton = (ImageButton) view.findViewById(R.id.sliding_card_dismiss);
 
-        Picasso.with(parent.getContext())
-                .load(imageUri)
-                .placeholder(R.drawable.ic_person)
-                .error(R.drawable.ic_person)
-                .into(mAvatarImageView);
+        final Button seeMoreButton = (Button) view.findViewById(R.id.sliding_card_see_more);
+        final ImageButton dismissButton = (ImageButton) view.findViewById(R.id.sliding_card_dismiss);
 
-        mNameTextView.setText(name);
-        mContentTextView.setText(content);
-        mSeeMoreButton.setOnClickListener(this);
-        mDismissButton.setOnClickListener(this);
+        setImageUri(imageUri);
+        setName(name);
+        setContent(content);
+
+        seeMoreButton.setOnClickListener(this);
+        dismissButton.setOnClickListener(this);
 
         return view;
     }
@@ -128,6 +133,37 @@ public final class AvatarCardAdapter implements SlidingView, View.OnClickListene
     public interface OnClickListener {
         void onSeeMoreClick();
         void onDismissClick();
+    }
+
+    /**
+     * {@link OnClickListener} implementations that simply Logs click events. Supplying a
+     * {@link SlidingViewManager} will animate the sliding view during an {@link #onDismissClick()}
+     */
+    @SuppressWarnings("unused")
+    public static class SimpleOnClickListener implements OnClickListener {
+
+        @Nullable
+        private final SlidingViewManager mManager;
+
+        public SimpleOnClickListener() {
+            this(null);
+        }
+
+        public SimpleOnClickListener(@Nullable SlidingViewManager manager) {
+            mManager = manager;
+        }
+
+        @Override
+        public void onSeeMoreClick() {
+            Log.i(getClass().getSimpleName(), "See More Clicked");
+        }
+
+        @Override
+        public void onDismissClick() {
+            Log.i(getClass().getSimpleName(), "Dismiss Clicked");
+            if (mManager != null) mManager.animate();
+        }
+
     }
 
     public static final class Options implements Parcelable {

--- a/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/AvatarCardAdapter.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/view/slidingview/AvatarCardAdapter.java
@@ -50,10 +50,8 @@ public final class AvatarCardAdapter implements SlidingView, View.OnClickListene
     }
 
     public void setImageUri(String imageUri) {
-        if (imageUri == null) {
-            setImageUri(Uri.EMPTY);
-        }
-        setImageUri(Uri.parse(imageUri));
+        final Uri uri = (imageUri == null) ? Uri.EMPTY : Uri.parse(imageUri);
+        setImageUri(uri);
     }
 
     public void setImageUri(Uri imageUri) {

--- a/app/src/main/java/com/google/developer/udacityalumni/viewholder/PostViewHolder.java
+++ b/app/src/main/java/com/google/developer/udacityalumni/viewholder/PostViewHolder.java
@@ -1,7 +1,10 @@
 package com.google.developer.udacityalumni.viewholder;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
@@ -11,6 +14,7 @@ import com.bumptech.glide.Glide;
 import com.firebase.ui.storage.images.FirebaseImageLoader;
 import com.google.developer.udacityalumni.R;
 import com.google.developer.udacityalumni.model.Post;
+import com.google.developer.udacityalumni.view.slidingview.AvatarCardAdapter;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 import com.squareup.picasso.Picasso;
@@ -23,6 +27,7 @@ import de.hdodenhof.circleimageview.CircleImageView;
 public class PostViewHolder extends RecyclerView.ViewHolder{
 
     private static final String LOG_TAG = PostViewHolder.class.getSimpleName();
+
     @BindView(R.id.item_post_text)
     TextView mTextTv;
     @BindView(R.id.item_post_image)
@@ -39,34 +44,48 @@ public class PostViewHolder extends RecyclerView.ViewHolder{
         ButterKnife.bind(this, itemView);
     }
 
-    public void bindToPost(Post post, Context context, FirebaseStorage storage){
-        if (post != null){
-            if (post.text != null && !post.text.isEmpty()) mTextTv.setText(post.text);
-            if (post.userName != null && !post.userName.isEmpty()) mUserNameTv.setText(post.userName);
-//            TODO: Add TimeAgo
-//            TODO: Add Comments
-//            TODO: Add OnClickListener
-            if (post.userProfPic != null && !post.userProfPic.isEmpty()) {
-                Picasso.with(context).load(post.userProfPic).placeholder(R.drawable.placeholder)
-                        .error(R.drawable.ic_person).into(mProfPicIv);
-            } else{
-                mProfPicIv.setImageResource(R.drawable.ic_person);
-            }
-            if (post.photoUrl != null && !post.photoUrl.isEmpty()){
-                Log.i(LOG_TAG, post.photoUrl);
-                StorageReference ref = storage.getReferenceFromUrl(post.photoUrl);
-                Glide.with(context)
-                        .using(new FirebaseImageLoader())
-                        .load(ref)
-                        .into(mImageIv);
-            }
-//            if (post.photoUrl != null && !post.photoUrl.isEmpty()){
-//                mProfPicIv.setVisibility(View.VISIBLE);
-//                Picasso.with(context).load(post.photoUrl)
-//                        .placeholder(R.drawable.placeholder).into(mImageIv);
-//            }
-//        } else{
-//            Log.i(LOG_TAG, "Post is null");
+    public void bindToPost(@Nullable Post post, @NonNull Context context, @NonNull FirebaseStorage storage){
+
+        if (post == null) {
+            return;
         }
+
+        final String text = post.text;
+        final String userName = post.userName;
+        final String userProfilePic = post.userProfPic;
+        final String photoUrl = post.photoUrl;
+
+        if (!TextUtils.isEmpty(text)) {
+            mTextTv.setText(text);
+        }
+
+        if(!TextUtils.isEmpty(userName)) {
+            mUserNameTv.setText(userName);
+        }
+
+        Picasso.with(context)
+                .load(userProfilePic)
+                .placeholder(R.drawable.placeholder)
+                .error(R.drawable.placeholder)
+                .into(mProfPicIv);
+
+        if(!TextUtils.isEmpty(photoUrl)) {
+            Log.i(LOG_TAG, photoUrl);
+            final StorageReference reference = storage.getReferenceFromUrl(photoUrl);
+            Glide.with(context)
+                    .using(new FirebaseImageLoader())
+                    .load(reference)
+                    .into(mImageIv);
+        }
+
+        //TODO: Add TimeAgo
+        //TODO: Add Comments
+        //TODO: Add OnClickListener
+
     }
+
+    public void setAvatarOnClickListener(View.OnClickListener listener) {
+        mProfPicIv.setOnClickListener(listener);
+    }
+
 }


### PR DESCRIPTION
### Summary

Re-adds animated sliding cards for user bios. Clicking on an avatar image in a post under the "Home" tab will open a card from the bottom of the screen that contains the user's profile picture, name and (for now) text from the post.

### Other Information

This commit includes some refactoring. Some logic is moved from `PostFragment` into a new `PostFirebaseAdapter` class.

I have included a `ToDo` for the Sliding Card as the content should eventually include the user's biography data.

```
PostFragment.class
//...
+        //todo Replace 'Content' with User Bio
+        mSlidingViewAdapter.setContent(post.text);
```

See: Issue #5, #32 